### PR TITLE
Add permission check to track command

### DIFF
--- a/src/commands/track.js
+++ b/src/commands/track.js
@@ -1,20 +1,29 @@
-module.exports = function createTrackCommand({ fetchQueues, buildEmbed, messaging, tracking }) {
-  return {
-    name: 'track',
-    async execute(message) {
-      try {
-        const data = await fetchQueues();
-        const embed = buildEmbed(data);
-        const sent = await messaging.send(message.channel, { embeds: [embed] });
-        if (!sent) return;
+const {PermissionsBitField} = require('discord.js');
 
-        tracking.start(sent, fetchQueues);
-        await messaging.reply(message, 'Tracking this message. It will update every 1 minute.').catch(() => {});
-      } catch (err) {
-        console.error('track command failed', err);
-      }
-    }
-  };
+module.exports = function createTrackCommand({fetchQueues, buildEmbed, messaging, tracking}) {
+    return {
+        name: 'track',
+        async execute(message) {
+            // check if user has permission to manage channels
+            if (!message.member.permissions.has(PermissionsBitField.Flags.ManageChannels)) {
+                await messaging.reply(message, 'You do not have permission to use this command.');
+                throw new Error(`User ${message.author.tag} attempted to use track command without permission.`);
+            }
+
+            try {
+                const data = await fetchQueues();
+                const embed = buildEmbed(data);
+                const sent = await messaging.send(message.channel, {embeds: [embed]});
+                if (!sent) return;
+
+                tracking.start(sent, fetchQueues);
+                await messaging.reply(message, 'Tracking this message. It will update every 1 minute.').catch(() => {
+                });
+            } catch (err) {
+                console.error('track command failed', err);
+            }
+        }
+    };
 };
 
 


### PR DESCRIPTION
The track command now checks if the user has the Manage Channels permission before executing. If the user lacks permission, a message is sent and the command does not proceed, improving security and preventing unauthorized usage.