### PR TITLE
Add per-role queue tracking and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ dist
 .yarn/install-state.gz
 .pnp.*
 config.json
+
+.idea
+
+.env.example

--- a/src/api.js
+++ b/src/api.js
@@ -5,11 +5,18 @@ const Joi = require('joi');
 const crypto = require('crypto');
 const { getItemLevel, getLevel, supportIds } = require('./data/xmlData');
 
+const RolesEnum = {
+  TANK: 0,
+  DD: 1,
+  HEAL: 2
+}
+
 class QueueManager {
   constructor() {
     this.queues = {
       dungeons: new Map(),
-      bgs: new Map()
+      bgs: new Map(),
+      rolePerInstance: new Map()
     };
     this.lastUpdated = new Date();
     this.sortedDungeonKeys = [];
@@ -19,15 +26,36 @@ class QueueManager {
     };
   }
 
+  roleCount(roles, players, key, DEBUG_BFP) {
+    if (roles && typeof roles === 'object') {
+      const roleCounts = {TANK: 0, DD: 0, HEAL: 0};
+
+      if (typeof roles[RolesEnum.TANK] === 'number') roleCounts.TANK = roles[RolesEnum.TANK];
+      if (typeof roles[RolesEnum.DD] === 'number') roleCounts.DD = roles[RolesEnum.DD];
+      if (typeof roles[RolesEnum.HEAL] === 'number') roleCounts.HEAL = roles[RolesEnum.HEAL];
+      if (DEBUG_BFP) {
+        console.log(`QueueManager: Added ${players} players to ${key} with roles ${JSON.stringify(roleCounts)}`);
+      }
+
+      const roleKey = `${key}:roles`;
+      const currentRoles = this.queues.rolePerInstance.get(roleKey) || {TANK: 0, DD: 0, HEAL: 0};
+      this.queues.rolePerInstance.set(roleKey, {
+        TANK: currentRoles.TANK + roleCounts.TANK,
+        DD: currentRoles.DD + roleCounts.DD,
+        HEAL: currentRoles.HEAL + roleCounts.HEAL,
+      });
+    }
+  }
+
   // Simple add/subtract counting per instance
   // matching_state === 1 → add `players` to queued for each instance
   // matching_state === 0 → subtract `players` from queued for each instance
   updateQueue(queueData) {
-    const { type, players, instances, server, matching_state } = queueData;
-    
+    const { type, players, instances, server, matching_state, roles } = queueData;
+
     // Determine queue type: 0 = dungeons, 1 = battlegrounds
     const queueType = type === 0 ? 'dungeons' : 'bgs';
-    
+
     // Normalize Blast from the Past: replace classic group (from XML) with 9999, keep others
     const BLAST_GROUP = Array.from(supportIds || []);
     const incoming = (instances || []).map(String);
@@ -47,16 +75,25 @@ class QueueManager {
 
       if (matching_state === 1) {
         this.queues[queueType].set(key, current + Number(players || 0));
+        this.roleCount(roles, players, key, DEBUG_BFP);
       } else {
         const newValue = Math.max(0, current - Number(players || 0));
         if (newValue > 0) {
           this.queues[queueType].set(key, newValue);
+
+          let revers_roles = {};
+          if (roles && typeof roles === 'object') {
+            revers_roles[RolesEnum.TANK] = -Math.abs(roles[RolesEnum.TANK] || 0);
+            revers_roles[RolesEnum.DD] = -Math.abs(roles[RolesEnum.DD] || 0);
+            revers_roles[RolesEnum.HEAL] = -Math.abs(roles[RolesEnum.HEAL] || 0);
+          }
+          this.roleCount(revers_roles, players, key, DEBUG_BFP);
         } else {
           this.queues[queueType].delete(key);
         }
       }
     });
-    
+
     // Maintain player counters by server (players are per request, not per instance)
     {
       const map = this.playerCounters[queueType];
@@ -111,7 +148,24 @@ class QueueManager {
       .filter((key) => this.queues.dungeons.has(key))
       .map((key) => mapEntryToObj(key, this.queues.dungeons.get(key)));
 
+    dungeons.forEach(dungeon => {
+      const roleKey = `${dungeon.server}:${dungeon.instances[0]}:roles`;
+      if (this.queues.rolePerInstance.has(roleKey)) {
+        dungeon.roles = this.queues.rolePerInstance.get(roleKey);
+      } else {
+        dungeon.roles = {TANK: 0, DD: 0, HEAL: 0};
+      }
+    });
+
     const bgs = Array.from(this.queues.bgs.entries()).map(([key, queued]) => mapEntryToObj(key, queued));
+    bgs.forEach(bg => {
+      const roleKey = `${bg.server}:${bg.instances[0]}:roles`;
+      if (this.queues.rolePerInstance.has(roleKey)) {
+        bg.roles = this.queues.rolePerInstance.get(roleKey);
+      } else {
+        bg.roles = {TANK: 0, DD: 0, HEAL: 0};
+      }
+    });
 
     const sumMapValues = (map) => Array.from(map.values()).reduce((acc, v) => acc + v, 0);
     const playersTotals = {
@@ -147,16 +201,16 @@ const queueManager = new QueueManager();
 const SECURITY_CONFIG = {
   // Allowed server names (whitelist)
   ALLOWED_SERVERS: process.env.ALLOWED_SERVERS ? process.env.ALLOWED_SERVERS.split(',') : ['Yurian'],
-  
+
   // IP whitelist for write operations (optional)
   ALLOWED_IPS: process.env.ALLOWED_IPS ? process.env.ALLOWED_IPS.split(',') : null,
-  
+
   // Request timeout in milliseconds
   REQUEST_TIMEOUT: parseInt(process.env.REQUEST_TIMEOUT) || 30000,
-  
+
   // Maximum queue entries per server
   MAX_QUEUE_ENTRIES: parseInt(process.env.MAX_QUEUE_ENTRIES) || 100,
-  
+
   // Security event logging
   LOG_SECURITY_EVENTS: process.env.LOG_SECURITY_EVENTS === 'true'
 };
@@ -164,11 +218,11 @@ const SECURITY_CONFIG = {
 // Security event logger
 const logSecurityEvent = (event, req, details = {}) => {
   if (!SECURITY_CONFIG.LOG_SECURITY_EVENTS) return;
-  
+
   const timestamp = new Date().toISOString();
   const ip = req.ip || req.connection.remoteAddress;
   const userAgent = req.get('User-Agent') || 'Unknown';
-  
+
   console.log(`[SECURITY] ${timestamp} - ${event}`, {
     ip,
     userAgent,
@@ -184,14 +238,19 @@ const queueDataSchema = Joi.object({
   players: Joi.number().integer().min(0).max(1000).required(),
   instances: Joi.array().items(Joi.string().max(50)).max(20).required(),
   server: Joi.string().max(50).required(),
-  matching_state: Joi.number().integer().min(0).max(1).required()
+  matching_state: Joi.number().integer().min(0).max(1).required(),
+  roles: Joi.object().keys({
+    0: Joi.number().integer().min(0).max(1000).required(), // tanks
+    1: Joi.number().integer().min(0).max(1000).required(), // dps
+    2: Joi.number().integer().min(0).max(1000).required(), // healers
+  }).optional(),
 });
 
 const serverNameSchema = Joi.string().max(50).pattern(/^[a-zA-Z0-9_-]+$/);
 
 function createApiServer(port = 3000) {
   const app = express();
-  
+
   app.use(helmet({
     contentSecurityPolicy: {
       directives: {
@@ -207,17 +266,17 @@ function createApiServer(port = 3000) {
       preload: true
     }
   }));
-  
+
   app.use(cors({
     origin: process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : ['http://localhost:3000'],
     credentials: true,
     methods: ['GET', 'POST', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization']
   }));
-  
+
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
-  
+
   app.use((req, res, next) => {
     req.setTimeout(SECURITY_CONFIG.REQUEST_TIMEOUT, () => {
       logSecurityEvent('REQUEST_TIMEOUT', req);
@@ -225,7 +284,7 @@ function createApiServer(port = 3000) {
     });
     next();
   });
-  
+
   const normalizeIP = (ip) => {
     if (!ip) return ip;
     const v4mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(ip);
@@ -256,132 +315,132 @@ function createApiServer(port = 3000) {
 
     next();
   };
-  
+
   app.use(ipWhitelistMiddleware);
-  
+
   app.use((req, res, next) => {
     const fingerprint = crypto.createHash('sha256')
       .update(req.ip + req.get('User-Agent') + req.get('Accept-Language'))
       .digest('hex')
       .substring(0, 16);
-    
+
     req.fingerprint = fingerprint;
     next();
   });
-  
+
   const validateApiKey = (req, res, next) => {
     const authHeader = req.headers.authorization;
     const expectedApiKey = process.env.API_KEY;
-    
+
     if (!expectedApiKey) {
       logSecurityEvent('API_KEY_NOT_CONFIGURED', req);
       return res.status(401).end();
     }
-    
+
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       logSecurityEvent('INVALID_AUTH_HEADER', req);
       return res.status(401).end();
     }
-    
+
     const providedKey = authHeader.substring(7);
-    
+
     // Constant-time comparison to prevent timing attacks
     const isValid = crypto.timingSafeEqual(
       Buffer.from(providedKey, 'utf8'),
       Buffer.from(expectedApiKey, 'utf8')
     );
-    
+
     if (!isValid) {
-      logSecurityEvent('INVALID_API_KEY', req, { 
+      logSecurityEvent('INVALID_API_KEY', req, {
         fingerprint: req.fingerprint,
-        keyLength: providedKey.length 
+        keyLength: providedKey.length
       });
       return res.status(401).end();
     }
-    
+
     next();
   };
-  
+
   const validateInput = (schema) => {
     return (req, res, next) => {
-      const { error, value } = schema.validate(req.body, { 
+      const { error, value } = schema.validate(req.body, {
         abortEarly: false,
-        stripUnknown: true 
+        stripUnknown: true
       });
-      
+
       if (error) {
-        logSecurityEvent('VALIDATION_ERROR', req, { 
+        logSecurityEvent('VALIDATION_ERROR', req, {
           errors: error.details.map(d => d.message),
-          fingerprint: req.fingerprint 
+          fingerprint: req.fingerprint
         });
         return res.status(400).end();
       }
-      
+
       req.body = value; // Use sanitized data
       next();
     };
   };
-  
+
   const validateServerName = (req, res, next) => {
     const serverName = req.params.server;
     const { error } = serverNameSchema.validate(serverName);
-    
+
     if (error) {
-      logSecurityEvent('INVALID_SERVER_NAME', req, { 
+      logSecurityEvent('INVALID_SERVER_NAME', req, {
         serverName,
-        fingerprint: req.fingerprint 
+        fingerprint: req.fingerprint
       });
       return res.status(400).end();
     }
-    
+
     if (!SECURITY_CONFIG.ALLOWED_SERVERS.includes(serverName)) {
-      logSecurityEvent('UNAUTHORIZED_SERVER', req, { 
+      logSecurityEvent('UNAUTHORIZED_SERVER', req, {
         serverName,
         allowedServers: SECURITY_CONFIG.ALLOWED_SERVERS,
-        fingerprint: req.fingerprint 
+        fingerprint: req.fingerprint
       });
       return res.status(403).end();
     }
-    
+
     next();
   };
-  
+
   // No per-request logging in production
-  
+
   const v1Router = express.Router();
-  
+
   app.get('/health', (req, res) => {
-    res.json({ 
-      status: 'ok', 
+    res.json({
+      status: 'ok',
       timestamp: new Date().toISOString(),
       version: '1.0.0',
       uptime: process.uptime()
     });
   });
-  
+
   v1Router.get('/health', (req, res) => {
-    res.json({ 
-      status: 'ok', 
+    res.json({
+      status: 'ok',
       timestamp: new Date().toISOString(),
       version: '1.0.0'
     });
   });
-  
+
   v1Router.get('/servers/:server/queues', validateServerName, (req, res) => {
     const { server } = req.params;
     const queues = queueManager.getQueues();
-    
+
     res.json({
       server,
       data: queues,
       timestamp: new Date().toISOString()
     });
   });
-  
+
   v1Router.get('/servers/:server/queues/:type', validateServerName, (req, res) => {
     const { server, type } = req.params;
     const queues = queueManager.getQueues();
-    
+
     if (type === 'dungeons') {
       res.json({
         server,
@@ -392,51 +451,51 @@ function createApiServer(port = 3000) {
     } else if (type === 'battlegrounds') {
       res.json({
         server,
-        type: 'battlegrounds', 
+        type: 'battlegrounds',
         data: queues.bgs,
         timestamp: new Date().toISOString()
       });
     } else {
-      logSecurityEvent('INVALID_QUEUE_TYPE', req, { type, fingerprint: req.fingerprint });
+      logSecurityEvent('INVALID_QUEUE_TYPE', req, {type, fingerprint: req.fingerprint});
       res.status(400).end();
     }
   });
-  
-  v1Router.post('/servers/:server/queues', 
-    validateApiKey, 
+
+  v1Router.post('/servers/:server/queues',
+    validateApiKey,
     validateServerName,
     validateInput(queueDataSchema),
     (req, res) => {
       const { server } = req.params;
       const queueData = req.body;
-      
+
       // Additional server name validation in body
       if (queueData.server !== server) {
-        logSecurityEvent('SERVER_NAME_MISMATCH', req, { 
-          urlServer: server, 
+        logSecurityEvent('SERVER_NAME_MISMATCH', req, {
+          urlServer: server,
           bodyServer: queueData.server,
-          fingerprint: req.fingerprint 
+          fingerprint: req.fingerprint
         });
         return res.status(400).end();
       }
-      
+
       queueManager.updateQueue(queueData);
-      res.json({ 
-        success: true, 
+      res.json({
+        success: true,
         server,
-        timestamp: new Date().toISOString() 
+        timestamp: new Date().toISOString()
       });
     }
   );
-  
-  v1Router.delete('/servers/:server/queues', 
-    validateApiKey, 
+
+  v1Router.delete('/servers/:server/queues',
+    validateApiKey,
     validateServerName,
     (req, res) => {
       const { server } = req.params;
       queueManager.clearAll();
-      res.json({ 
-        success: true, 
+      res.json({
+        success: true,
         message: `All queues cleared for server: ${server}`,
         timestamp: new Date().toISOString()
       });
@@ -472,21 +531,21 @@ function createApiServer(port = 3000) {
       });
     }
   );
-  
+
   app.use('/api/v1', v1Router);
-  
+
   app.use((err, req, res, next) => {
     console.error('API Error:', err);
     res.status(500).json({ error: 'Internal server error' });
   });
-  
+
   app.use((req, res) => {
     res.status(404).json({ error: 'Endpoint not found' });
   });
-  
+
   // Start HTTP server only
   app.listen(port, () => {});
-  
+
   return app;
 }
 

--- a/src/fetchQueues.js
+++ b/src/fetchQueues.js
@@ -17,7 +17,7 @@ async function fetchQueues() {
         rejectUnauthorized: process.env.NODE_ENV === 'production' // Only reject in production
       })
     };
-    
+
     const [dungeonRes, bgRes] = await Promise.all([
       axios.get(DUNGEON_URL, axiosConfig),
       axios.get(BG_URL, axiosConfig)
@@ -61,11 +61,13 @@ function formatList(items) {
     const wait = it.avgWait || it.average || it.wait || null;
     const qty = queued !== undefined ? queued.toString() : '-';
     const waitTxt = wait ? String(wait) : '';
+    const rolesTxt = it.roles ? ` [🛡️:${it.roles.TANK || 0} ⚔️:${it.roles.DD || 0} 🪄:${it.roles.HEAL || 0}]` : '';
 
     return displayNames.map((name) => {
       const left = name.length > 38 ? name.slice(0, 37) + '…' : name;
-      const padded = left.padEnd(40, ' ');
-      return `${padded} ${qty}${waitTxt ? `  (${waitTxt})` : ''}`;
+      const padded = left.padEnd(30, ' ');
+
+      return `${padded} ${qty}${waitTxt ? `  (${waitTxt})` : ''}${rolesTxt}`;
     });
   });
 
@@ -117,7 +119,7 @@ function dynamicColor(totalQueued) {
 }
 
 function buildEmbed(data) {
-  const { dungeons, bgs, playersTotals } = data;
+  const { dungeons, bgs, playersTotals, roles } = data;
   const { endTxt, lvlTxt, endCount, lvlCount } = formatDungeonSections(dungeons);
   const totalDQueues = endCount + lvlCount;
   const totalBQueues = sumQueued(bgs);


### PR DESCRIPTION
Introduces role-based queue tracking in QueueManager, storing and updating counts for TANK, DD, and HEAL roles per instance. The API now accepts an optional 'roles' object in queue updates, and the fetchQueues output displays role counts for each queue entry. This enhances queue visibility and enables more granular monitoring of group composition.