### PR TITLE
ci: add PR-only validation workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,35 @@
+name: PR CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Node repo on Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check
+        run: npm run check:syntax
+
+      - name: Test suite
+        run: npm test
+
+      - name: Startup sanity
+        run: npm run ci:startup

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Discord bot that displays and tracks TERA queue status for Dungeons and Battlegr
    LOG_SECURITY_EVENTS=true
    NODE_ENV=production
    ```
-4. Start the bot (this will start both the Discord bot and API server):
+4. Run the local validation suite before opening a PR:
+   ```bash
+   npm run check:syntax
+   npm test
+   npm run ci:startup
+   ```
+5. Start the bot (this will start both the Discord bot and API server):
    ```bash
    npm start
    ```
@@ -123,6 +129,11 @@ In any text channel where the bot has access:
 - The API server runs on the same process as the Discord bot for simplicity.
 - HTTPS server with SSL certificate support (falls back to HTTP if certificates not found).
 - Comprehensive security middleware including rate limiting, CORS, and API key authentication.
+
+## CI coverage
+- PR CI runs only on `pull_request` via GitHub Actions.
+- The workflow performs real dependency install (`npm ci`), JavaScript syntax validation, the Node test suite, and a startup sanity check that boots the internal API and exercises queue endpoints.
+- This repo does **not** currently ship an ESLint config or a build step, so the CI intentionally does not pretend those checks exist.
 
 ## Troubleshooting
 - If the bot does not respond to commands:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "check:syntax": "node scripts/check-syntax.js",
+    "test": "node --test",
+    "ci:startup": "node scripts/startup-sanity.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/check-syntax.js
+++ b/scripts/check-syntax.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function collectJsFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.js')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const root = path.join(__dirname, '..', 'src');
+const files = collectJsFiles(root);
+
+for (const file of files) {
+  const code = fs.readFileSync(file, 'utf8');
+  try {
+    new vm.Script(code, { filename: file });
+  } catch (error) {
+    console.error(`Syntax error in ${path.relative(process.cwd(), file)}`);
+    throw error;
+  }
+}
+
+console.log(`Syntax OK: ${files.length} files`);

--- a/scripts/startup-sanity.js
+++ b/scripts/startup-sanity.js
@@ -1,0 +1,73 @@
+const assert = require('assert/strict');
+
+async function main() {
+  process.env.API_KEY = process.env.API_KEY || 'ci-test-key';
+  process.env.ALLOWED_SERVERS = process.env.ALLOWED_SERVERS || 'Yurian';
+  process.env.ALLOWED_IPS = '';
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+  const { createApiServer, queueManager } = require('../src/api');
+  const { createClient } = require('../src/discord/client');
+  const { buildEmbed } = require('../src/fetchQueues');
+
+  queueManager.clearAll();
+
+  const app = createApiServer(0);
+  const server = app.server;
+  assert.ok(server, 'API server should expose the underlying http server');
+
+  const port = server.address().port;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const healthResponse = await fetch(`${baseUrl}/health`);
+  assert.equal(healthResponse.status, 200, 'health endpoint should respond');
+
+  const payload = {
+    type: 0,
+    players: 3,
+    instances: ['9025'],
+    server: 'Yurian',
+    matching_state: 1,
+    roles: { TANK: 1, DD: 1, HEAL: 1 }
+  };
+
+  const postResponse = await fetch(`${baseUrl}/api/v1/servers/Yurian/queues`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${process.env.API_KEY}`
+    },
+    body: JSON.stringify(payload)
+  });
+  assert.equal(postResponse.status, 200, 'queue update should succeed');
+
+  const queuesResponse = await fetch(`${baseUrl}/api/v1/servers/Yurian/queues`);
+  assert.equal(queuesResponse.status, 200, 'queue read should succeed');
+  const queuesJson = await queuesResponse.json();
+  assert.equal(queuesJson.data.dungeons.length, 1, 'startup sanity should see one dungeon queue');
+
+  const embed = buildEmbed({
+    dungeons: queuesJson.data.dungeons,
+    bgs: [],
+    playersTotals: queuesJson.data.playersTotals,
+  });
+  assert.equal(embed.fields.length, 3, 'embed should render expected sections');
+
+  const client = createClient();
+  assert.equal(typeof client.login, 'function', 'discord client should be creatable without logging in');
+  client.destroy();
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+
+  console.log('Startup sanity passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/api.js
+++ b/src/api.js
@@ -400,12 +400,11 @@ function createApiServer(port = 3000) {
     }
 
     const providedKey = authHeader.substring(7);
+    const providedKeyBuffer = Buffer.from(providedKey, 'utf8');
+    const expectedKeyBuffer = Buffer.from(expectedApiKey, 'utf8');
 
-    // Constant-time comparison to prevent timing attacks
-    const isValid = crypto.timingSafeEqual(
-      Buffer.from(providedKey, 'utf8'),
-      Buffer.from(expectedApiKey, 'utf8')
-    );
+    const isValid = providedKeyBuffer.length === expectedKeyBuffer.length
+      && crypto.timingSafeEqual(providedKeyBuffer, expectedKeyBuffer);
 
     if (!isValid) {
       logSecurityEvent('INVALID_API_KEY', req, {
@@ -605,7 +604,8 @@ function createApiServer(port = 3000) {
   });
 
   // Start HTTP server only
-  app.listen(port, () => {});
+  const server = app.listen(port, () => {});
+  app.server = server;
 
   return app;
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,135 @@
+const test = require('node:test');
+const assert = require('assert/strict');
+
+process.env.API_KEY = 'test-api-key';
+process.env.ALLOWED_SERVERS = 'Yurian';
+process.env.ALLOWED_IPS = '';
+process.env.NODE_ENV = 'test';
+
+const { createApiServer, queueManager } = require('../src/api');
+
+let app;
+let server;
+let baseUrl;
+
+async function jsonFetch(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const contentType = response.headers.get('content-type') || '';
+  const body = contentType.includes('application/json') ? await response.json() : undefined;
+  return { response, body };
+}
+
+test.before(async () => {
+  queueManager.clearAll();
+  app = createApiServer(0);
+  server = app.server;
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.after(async () => {
+  if (!server) return;
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+});
+
+test('health endpoint reports ok', async () => {
+  const { response, body } = await jsonFetch('/health');
+  assert.equal(response.status, 200);
+  assert.equal(body.status, 'ok');
+});
+
+test('queue lifecycle works for a valid authenticated request', async () => {
+  queueManager.clearAll();
+
+  const payload = {
+    type: 0,
+    players: 3,
+    instances: ['9025'],
+    server: 'Yurian',
+    matching_state: 1,
+    roles: { TANK: 1, DD: 1, HEAL: 1 }
+  };
+
+  const post = await jsonFetch('/api/v1/servers/Yurian/queues', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer test-api-key'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  assert.equal(post.response.status, 200);
+  assert.equal(post.body.success, true);
+
+  const get = await jsonFetch('/api/v1/servers/Yurian/queues');
+  assert.equal(get.response.status, 200);
+  assert.equal(get.body.data.dungeons.length, 1);
+  assert.equal(get.body.data.dungeons[0].queued, 3);
+  assert.deepEqual(get.body.data.dungeons[0].roles, { TANK: 1, DD: 1, HEAL: 1 });
+});
+
+test('write endpoints reject invalid API keys', async () => {
+  const payload = {
+    type: 0,
+    players: 1,
+    instances: ['9025'],
+    server: 'Yurian',
+    matching_state: 1,
+  };
+
+  const result = await jsonFetch('/api/v1/servers/Yurian/queues', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer wrong-key'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  assert.equal(result.response.status, 401);
+});
+
+test('type-specific delete clears only the selected queue type', async () => {
+  queueManager.clearAll();
+
+  const headers = {
+    'content-type': 'application/json',
+    authorization: 'Bearer test-api-key'
+  };
+
+  await jsonFetch('/api/v1/servers/Yurian/queues', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      type: 0,
+      players: 2,
+      instances: ['9025'],
+      server: 'Yurian',
+      matching_state: 1,
+      roles: { TANK: 1, DD: 1, HEAL: 0 }
+    })
+  });
+
+  await jsonFetch('/api/v1/servers/Yurian/queues', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      type: 1,
+      players: 10,
+      instances: ['5'],
+      server: 'Yurian',
+      matching_state: 1
+    })
+  });
+
+  const del = await jsonFetch('/api/v1/servers/Yurian/queues/dungeons', {
+    method: 'DELETE',
+    headers: { authorization: 'Bearer test-api-key' }
+  });
+
+  assert.equal(del.response.status, 200);
+
+  const get = await jsonFetch('/api/v1/servers/Yurian/queues');
+  assert.equal(get.body.data.dungeons.length, 0);
+  assert.equal(get.body.data.bgs.length, 1);
+});

--- a/test/fetchQueues.test.js
+++ b/test/fetchQueues.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('assert/strict');
+
+process.env.API_KEY = 'test-api-key';
+process.env.ALLOWED_SERVERS = 'Yurian';
+process.env.ALLOWED_IPS = '';
+process.env.NODE_ENV = 'test';
+
+const { createApiServer, queueManager } = require('../src/api');
+
+let app;
+let server;
+let baseUrl;
+
+function freshFetchQueuesModule() {
+  delete require.cache[require.resolve('../src/fetchQueues')];
+  return require('../src/fetchQueues');
+}
+
+test.before(async () => {
+  queueManager.clearAll();
+  app = createApiServer(0);
+  server = app.server;
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.after(async () => {
+  if (!server) return;
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+});
+
+test('fetchQueues reads dungeon and battleground data from the internal API', async () => {
+  queueManager.clearAll();
+
+  const headers = {
+    'content-type': 'application/json',
+    authorization: 'Bearer test-api-key'
+  };
+
+  await fetch(`${baseUrl}/api/v1/servers/Yurian/queues`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      type: 0,
+      players: 3,
+      instances: ['9025'],
+      server: 'Yurian',
+      matching_state: 1,
+      roles: { TANK: 1, DD: 1, HEAL: 1 }
+    })
+  });
+
+  await fetch(`${baseUrl}/api/v1/servers/Yurian/queues`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      type: 1,
+      players: 10,
+      instances: ['5'],
+      server: 'Yurian',
+      matching_state: 1
+    })
+  });
+
+  process.env.API_BASE_URL = baseUrl;
+  process.env.SERVER_NAME = 'Yurian';
+
+  const { fetchQueues, buildEmbed } = freshFetchQueuesModule();
+  const result = await fetchQueues();
+
+  assert.equal(result.dungeons.length, 1);
+  assert.equal(result.bgs.length, 1);
+
+  const embed = buildEmbed(result);
+  assert.equal(embed.fields.length, 3);
+  assert.match(embed.fields[0].name, /Dungeons/);
+  assert.match(embed.fields[2].name, /Battlegrounds/);
+});


### PR DESCRIPTION
## Summary
- add a PR-only GitHub Actions workflow on Ubuntu for this Node repo
- install dependencies with `npm ci` and run the strongest real checks the repo now supports
- add real Node tests and startup sanity instead of placeholder CI steps
- fix invalid API key handling so bad credentials return 401 instead of crashing into a 500

## Checks
- `npm ci`
- `npm run check:syntax`
- `npm test`
- `npm run ci:startup`

## Honest gaps
- this repo does not currently have an ESLint config, so there is no lint job yet
- this repo does not have a separate build step; startup sanity is the closest truthful runtime validation
- there were no existing Claude Code or Gemini workflow files in-repo to remove, so the branch leaves no duplicate AI review workflows behind

Closes #8